### PR TITLE
Declare global variable for byte compile warning

### DIFF
--- a/rope-read-mode.el
+++ b/rope-read-mode.el
@@ -119,6 +119,9 @@
   "Template for the filenames to be written to disk.")
 (defvar rope-read-mode nil)
 (make-variable-buffer-local 'rope-read-mode)
+
+(defvar rope-read-old-buffer-read-only)
+(make-variable-buffer-local 'rope-read-old-buffer-read-only)
 ;; #+END_SRC
 ;; ** Keys
 ;; #+BEGIN_SRC emacs-lisp


### PR DESCRIPTION
And it is also declared as buffer local variable, because
buffer-read-only is a buffer local variable.

I got following error with original code when I byte-compile.
```
In rope-read-mode-enable:
rope-read-mode.el:163:9:Warning: assignment to free variable
    `rope-read-old-buffer-read-only'

In rope-read-mode-disable:
rope-read-mode.el:171:26:Warning: reference to free variable
    `rope-read-old-buffer-read-only'
```